### PR TITLE
Uploading images to the server

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -58,7 +58,7 @@ config :tweeter, TweeterWeb.Endpoint,
 config :tweeter, TweeterWeb.Endpoint,
   live_reload: [
     patterns: [
-      ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",
+      ~r"priv/static/[^uploads].*(js|css|png|jpeg|jpg|gif|svg)$",
       ~r"priv/gettext/.*(po)$",
       ~r"lib/tweeter_web/(live|views)/.*(ex)$",
       ~r"lib/tweeter_web/templates/.*(eex)$"

--- a/lib/tweeter/timeline.ex
+++ b/lib/tweeter/timeline.ex
@@ -49,10 +49,11 @@ defmodule Tweeter.Timeline do
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_post(attrs \\ %{}) do
-    %Post{}
+  def create_post(%Post{} = post, attrs \\ %{}, after_save \\ &{:ok, &1}) do
+    post
     |> Post.changeset(attrs)
     |> Repo.insert()
+    |> after_save(after_save)
     |> broadcast(:post_created)
   end
 
@@ -68,12 +69,19 @@ defmodule Tweeter.Timeline do
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_post(%Post{} = post, attrs) do
+  def update_post(%Post{} = post, attrs,  after_save \\ &{:ok, &1}) do
     post
     |> Post.changeset(attrs)
     |> Repo.update()
+    |> after_save(after_save)
     |> broadcast(:post_updated)
   end
+
+  def after_save({:ok, post}, func) do
+    {:ok, _post} = func.(post)
+  end
+
+  def after_save(error, _func), do: error
 
   @doc """
   Deletes a post.

--- a/lib/tweeter/timeline/post.ex
+++ b/lib/tweeter/timeline/post.ex
@@ -7,6 +7,7 @@ defmodule Tweeter.Timeline.Post do
     field :likes_count, :integer, default: 0
     field :reposts_count, :integer, default: 0
     field :username, :string, default: "test_user"
+    field :photo_urls, {:array, :string}, default: []
 
     timestamps()
   end

--- a/lib/tweeter_web/endpoint.ex
+++ b/lib/tweeter_web/endpoint.ex
@@ -24,7 +24,7 @@ defmodule TweeterWeb.Endpoint do
     at: "/",
     from: :tweeter,
     gzip: false,
-    only: ~w(css fonts images js favicon.ico robots.txt)
+    only: ~w(css fonts images js favicon.ico robots.txt uploads)
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.

--- a/lib/tweeter_web/live/post_live/form_component.ex
+++ b/lib/tweeter_web/live/post_live/form_component.ex
@@ -4,6 +4,11 @@ defmodule TweeterWeb.PostLive.FormComponent do
   alias Tweeter.Timeline
 
   @impl true
+  def mount(socket) do
+    {:ok, allow_upload(socket, :photo, accept: ~w(.png .jpg .jpeg), max_entries: 2)}
+  end
+
+  @impl true
   def update(%{post: post} = assigns, socket) do
     changeset = Timeline.change_post(post)
 
@@ -23,6 +28,7 @@ defmodule TweeterWeb.PostLive.FormComponent do
     {:noreply, assign(socket, :changeset, changeset)}
   end
 
+  @impl true
   def handle_event("save", %{"post" => post_params}, socket) do
     save_post(socket, socket.assigns.action, post_params)
   end

--- a/lib/tweeter_web/live/post_live/form_component.ex
+++ b/lib/tweeter_web/live/post_live/form_component.ex
@@ -2,6 +2,7 @@ defmodule TweeterWeb.PostLive.FormComponent do
   use TweeterWeb, :live_component
 
   alias Tweeter.Timeline
+  alias Tweeter.Timeline.Post
 
   @impl true
   def mount(socket) do
@@ -29,12 +30,18 @@ defmodule TweeterWeb.PostLive.FormComponent do
   end
 
   @impl true
+  def handle_event("cancel-photo-upload", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :photo, ref)}
+  end
+
+  @impl true
   def handle_event("save", %{"post" => post_params}, socket) do
     save_post(socket, socket.assigns.action, post_params)
   end
 
   defp save_post(socket, :edit, post_params) do
-    case Timeline.update_post(socket.assigns.post, post_params) do
+    post = put_photo_urls(socket, socket.assigns.post)
+    case Timeline.update_post(post, post_params, &consume_photos(socket, &1)) do
       {:ok, _post} ->
         {:noreply,
          socket
@@ -47,7 +54,8 @@ defmodule TweeterWeb.PostLive.FormComponent do
   end
 
   defp save_post(socket, :new, post_params) do
-    case Timeline.create_post(post_params) do
+    post = put_photo_urls(socket, %Post{})
+    case Timeline.create_post(post, post_params, &consume_photos(socket, &1)) do
       {:ok, _post} ->
         {:noreply,
          socket
@@ -59,8 +67,25 @@ defmodule TweeterWeb.PostLive.FormComponent do
     end
   end
 
-  @impl true
-  def handle_event("cancel-photo-upload", %{"ref" => ref}, socket) do
-    {:noreply, cancel_upload(socket, :photo, ref)}
+  defp ext(entry) do
+    [ext | _] = MIME.extensions(entry.client_type)
+    ext
+  end
+
+  defp put_photo_urls(socket, %Post{} = post) do
+    {completed, []} = uploaded_entries(socket, :photo)
+    urls =
+      for entry <- completed do
+        Routes.static_path(socket, "/uploads/#{entry.uuid}.#{ext(entry)}")
+      end
+    %Post{post | photo_urls: urls}
+  end
+
+  defp consume_photos(socket, %Post{} = post) do
+    consume_uploaded_entries(socket, :photo, fn meta, entry ->
+      dest = Path.join("priv/static/uploads", "#{entry.uuid}.#{ext(entry)}")
+      File.cp!(meta.path, dest)
+    end)
+    {:ok, post}
   end
 end

--- a/lib/tweeter_web/live/post_live/form_component.ex
+++ b/lib/tweeter_web/live/post_live/form_component.ex
@@ -58,4 +58,9 @@ defmodule TweeterWeb.PostLive.FormComponent do
         {:noreply, assign(socket, changeset: changeset)}
     end
   end
+
+  @impl true
+  def handle_event("cancel-photo-upload", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :photo, ref)}
+  end
 end

--- a/lib/tweeter_web/live/post_live/form_component.html.leex
+++ b/lib/tweeter_web/live/post_live/form_component.html.leex
@@ -23,6 +23,12 @@
       <div class="column">
         <progress max="100" value="<%= entry.progress %>" />
       </div>
+      <div class="column">
+        <a href="#" phx-click="cancel-photo-upload" phx-value-ref="<%= entry.ref %>"
+           phx-target="<%= @myself %>">
+          Cancel
+        </a>
+      </div>
     </div>
   <% end %>
 

--- a/lib/tweeter_web/live/post_live/form_component.html.leex
+++ b/lib/tweeter_web/live/post_live/form_component.html.leex
@@ -10,5 +10,21 @@
   <%= textarea f, :body %>
   <%= error_tag f, :body %>
 
+  <%= live_file_input @uploads.photo %>
+  <%= for {_ref, msg} <- @uploads.photo.errors do %>
+    <p class="alert alert-danger"><%= humanize(msg) %></p>
+  <% end %>
+
+  <%= for entry <- @uploads.photo.entries do%>
+    <div class="row">
+      <div class="column">
+        <%= live_img_preview entry, height: 80 %>
+      </div>
+      <div class="column">
+        <progress max="100" value="<%= entry.progress %>" />
+      </div>
+    </div>
+  <% end %>
+
   <%= submit "Save", phx_disable_with: "Saving..." %>
 </form>

--- a/lib/tweeter_web/live/post_live/index.html.leex
+++ b/lib/tweeter_web/live/post_live/index.html.leex
@@ -9,10 +9,9 @@
     return_to: Routes.post_index_path(@socket, :index) %>
 <% end %>
 
+<span><%= live_patch "New Post", to: Routes.post_index_path(@socket, :new) %></span>
 <div id="posts" phx-update="prepend">
   <%= for post <- @posts do %>
     <%= live_component @socket, TweeterWeb.PostLive.PostComponent, id: post.id, post: post %>
   <% end %>
 </div>
-
-<span><%= live_patch "New Post", to: Routes.post_index_path(@socket, :new) %></span>

--- a/lib/tweeter_web/live/post_live/post_component.ex
+++ b/lib/tweeter_web/live/post_live/post_component.ex
@@ -30,6 +30,11 @@ defmodule TweeterWeb.PostLive.PostComponent do
             <b><%= @post.username %></b>
             <br />
             <%= @post.body %>
+            <div class="column">
+              <%= for url <- @post.photo_urls do %>
+                <img src="<%=url%>" height="150" />
+              <% end %>
+            </div>
           </div>
         </div>
         <div class="row">

--- a/priv/repo/migrations/20210126074019_add_photo_urls_to_posts.exs
+++ b/priv/repo/migrations/20210126074019_add_photo_urls_to_posts.exs
@@ -1,0 +1,9 @@
+defmodule Tweeter.Repo.Migrations.AddPhotoUrlsToPosts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:posts) do
+      add :photo_urls, {:array, :string}, null: false, default: []
+    end
+  end
+end


### PR DESCRIPTION
1. Adding ability to upload images
2. Add ability to cancel/prune file uploads
3. Migrations & Config changes for photo uploads 
    Updating posts schema & table to accept photo urls
    Configuration Changes:
     - Update endpoint to serve static files from uploads directort
     - Prevent dev hot module reload on photo uploads
4. Uploading files directly to the server 
    Steps:
    - Generate static file upload path on the server
    - Save the image urls on server to the database
    - If successful, save the uploaded files to the static file path
    - Update ui to show the images